### PR TITLE
Double AME fuel capacity

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Power/antimatter_jar.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/antimatter_jar.yml
@@ -11,6 +11,8 @@
     sprite: Objects/Power/AME/ame_jar.rsi
     state: jar
   - type: AmeFuelContainer
+    fuelAmount: 1000 # Morbit
+    fuelCapacity: 1000 # Morbit
   - type: StaticPrice
     price: 500
   - type: GuideHelp


### PR DESCRIPTION
## About the PR
doubles the amount of AME fuel contained in one jar

## Why / Balance
we currently do not know how to set up the other generator types, and don't have a stable enough playerbase to efficiently acquire more jars

## Technical details
yml warrior with my 2 line change

## Requirements
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
:cl: sarcovyn
- tweak: AME fuel jars now hold 1000 fuel instead of 500.