### PR TITLE
Make other low-pop maps available

### DIFF
--- a/Resources/Prototypes/Maps/asterisk.yml
+++ b/Resources/Prototypes/Maps/asterisk.yml
@@ -2,7 +2,7 @@
   id: Asterisk
   mapName: 'Asterisk'
   mapPath: /Maps/asterisk.yml
-  minPlayers: 5
+  minPlayers: 0
   maxPlayers: 70 #80 available job slots that aren't passenger
   stations:
     Asterisk:

--- a/Resources/Prototypes/Maps/glacier.yml
+++ b/Resources/Prototypes/Maps/glacier.yml
@@ -2,7 +2,7 @@
   id: Glacier
   mapName: Glacier
   mapPath: /Maps/glacier.yml
-  minPlayers: 15
+  minPlayers: 0
   maxPlayers: 70
   stations:
     Glacier:

--- a/Resources/Prototypes/Maps/lighthouse.yml
+++ b/Resources/Prototypes/Maps/lighthouse.yml
@@ -2,7 +2,7 @@
   id: Lighthouse
   mapName: Lighthouse
   mapPath: /Maps/lighthouse.yml
-  minPlayers: 15
+  minPlayers: 0
   maxPlayers: 80
   stations:
     Lighthouse:

--- a/Resources/Prototypes/Maps/micro.yml
+++ b/Resources/Prototypes/Maps/micro.yml
@@ -2,7 +2,7 @@
   id: Micro
   mapName: 'Micro'
   mapPath: /Maps/micro.yml
-  minPlayers: 5
+  minPlayers: 0
   maxPlayers: 45
   stations:
     Micro:

--- a/Resources/Prototypes/Maps/shoukou.yml
+++ b/Resources/Prototypes/Maps/shoukou.yml
@@ -2,7 +2,7 @@
   id: Shoukou
   mapName: 'Shōkō'
   mapPath: /Maps/shoukou.yml
-  minPlayers: 5
+  minPlayers: 0
   maxPlayers: 60
   stations:
     Shoukou:


### PR DESCRIPTION
## About the PR
sets Micro, Shoko, Lighthouse, Asterisk, and Glacier to have minimum populations of 0.

## Why / Balance
gives us more map options

## Technical details
yml warrior with my 4 line change

## Requirements
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: sarcovyn
- tweak: Micro, Shoko, Lighthouse, Asterisk, and Glacier are now available at 0 population.
